### PR TITLE
Updates build.gradle for maven compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 .gradle
 .idea
 *.iml
+local.properties
+

--- a/vtm-android/build.gradle
+++ b/vtm-android/build.gradle
@@ -1,13 +1,11 @@
-
 apply plugin: 'android-library'
 apply plugin: 'android-maven'
 
-
 dependencies {
-	compile fileTree(dir: '../vtm-ext-libs/libs', include: 'slf4j-api-1.7.5.jar')
 	compile fileTree(dir: "../vtm-ext-libs/vtm-android", include: 'native-libs-*.jar')
 	compile project(':vtm')
-	compile 'com.android.support:support-v4:+'
+	compile 'com.android.support:support-v4:19.0.1'
+	compile 'org.slf4j:slf4j-android:1.7.6'
 }
 
 android {


### PR DESCRIPTION
- Explicitly set support library version 19.0.1.
- Include slf4j-android dependency from maven central instead of local jar.
- Adds local.properties to .gitignore
