### PR TITLE
Fix broken import in vtm-jeo project.

### DIFF
--- a/vtm-jeo/src/org/oscim/layers/JeoTileSource.java
+++ b/vtm-jeo/src/org/oscim/layers/JeoTileSource.java
@@ -7,7 +7,7 @@ import static org.oscim.tiling.ITileDataSink.QueryResult.TILE_NOT_FOUND;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import org.jeo.data.Tile;
+import org.jeo.tile.Tile;
 import org.jeo.data.TileDataset;
 import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.canvas.Bitmap;


### PR DESCRIPTION
Resolves the following build error:

```
$ ./gradlew clean install
...
:vtm-jeo:compileJava
/usr/local/code/vtm/vtm-jeo/src/org/oscim/layers/JeoTileSource.java:10: error: cannot find symbol
import org.jeo.data.Tile;
                   ^
  symbol:   class Tile
  location: package org.jeo.data
/usr/local/code/vtm/vtm-jeo/src/org/oscim/layers/JeoTileSource.java:42: error: cannot find symbol
                    Tile t = mTileDataset.read(tile.zoomLevel, tile.tileX,
                    ^
  symbol: class Tile
2 errors
:vtm-jeo:compileJava FAILED

FAILURE: Build failed with an exception.
...
```
