### PR TITLE
Double tap to zoom

### DIFF
--- a/vtm-tests/test/org/oscim/layers/MapEventLayerTest.java
+++ b/vtm-tests/test/org/oscim/layers/MapEventLayerTest.java
@@ -12,6 +12,7 @@ import org.oscim.map.ViewController;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,21 +41,57 @@ public class MapEventLayerTest {
 	}
 
 	@Test
+	public void doubleTap_shouldAnimateZoom() throws Exception {
+		simulateDoubleTap();
+		verify(mockAnimator).animateZoom(300, 2, 0, 0);
+	}
+
+	@Test
+	public void doubleTap_shouldAnimateZoomAfterDoubleTouchDrag() throws Exception {
+		simulateDoubleTouchDragUp();
+		simulateDoubleTap();
+		verify(mockAnimator).animateZoom(300, 2, 0, 0);
+	}
+
+	@Test
+	public void doubleTouchDrag_shouldNotAnimateZoom() throws Exception {
+		simulateDoubleTouchDragUp();
+		verify(mockAnimator, never()).animateZoom(any(long.class), any(double.class),
+				any(float.class), any(float.class));
+	}
+
+	@Test
 	public void doubleTouchDragUp_shouldDecreaseContentScale() throws Exception {
-		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_DOWN, 1, 1));
-		layer.onGesture(Gesture.DOUBLE_TAP, new TestMotionEvent(MotionEvent.ACTION_MOVE, 1, 0));
-		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_MOVE, 1, 0));
+		simulateDoubleTouchDragUp();
 		verify(mockViewport).scaleMap(argumentCaptor.capture(), any(float.class), any(float.class));
 		assertThat(argumentCaptor.getValue()).isLessThan(1);
 	}
 
 	@Test
 	public void doubleTouchDragDown_shouldIncreaseContentScale() throws Exception {
+		simulateDoubleTouchDragDown();
+		verify(mockViewport).scaleMap(argumentCaptor.capture(), any(float.class), any(float.class));
+		assertThat(argumentCaptor.getValue()).isGreaterThan(1);
+	}
+
+	private void simulateDoubleTap() {
+		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_DOWN, 1, 1));
+		layer.onGesture(Gesture.DOUBLE_TAP, new TestMotionEvent(MotionEvent.ACTION_UP, 1, 1));
+		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_UP, 1, 1));
+	}
+
+	private void simulateDoubleTouchDragUp() {
+		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_DOWN, 1, 1));
+		layer.onGesture(Gesture.DOUBLE_TAP, new TestMotionEvent(MotionEvent.ACTION_MOVE, 1, 0));
+		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_MOVE, 1, 0));
+		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_UP, 1, 0));
+	}
+
+	private void simulateDoubleTouchDragDown() {
 		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_DOWN, 1, 1));
 		layer.onGesture(Gesture.DOUBLE_TAP, new TestMotionEvent(MotionEvent.ACTION_MOVE, 1, 2));
 		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_MOVE, 1, 2));
-		verify(mockViewport).scaleMap(argumentCaptor.capture(), any(float.class), any(float.class));
-		assertThat(argumentCaptor.getValue()).isGreaterThan(1);
+		layer.onTouchEvent(new TestMotionEvent(MotionEvent.ACTION_UP, 1, 2));
 	}
 
 	class TestMotionEvent extends MotionEvent {

--- a/vtm/src/org/oscim/layers/MapEventLayer.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer.java
@@ -54,6 +54,7 @@ public class MapEventLayer extends Layer implements InputListener, GestureListen
 
 	private boolean mDown;
 	private boolean mDoubleTap;
+	private boolean mDrag;
 
 	private float mPrevX1;
 	private float mPrevY1;
@@ -136,6 +137,12 @@ public class MapEventLayer extends Layer implements InputListener, GestureListen
 		}
 		if (action == MotionEvent.ACTION_UP) {
 			mDown = false;
+			if (mDoubleTap && !mDrag) {
+				mMap.animator().animateZoom(300, 2, 0, 0);
+			}
+
+			mDrag = false;
+
 			if (mStartMove < 0)
 				return true;
 
@@ -200,6 +207,7 @@ public class MapEventLayer extends Layer implements InputListener, GestureListen
 					return true;
 				}
 				// FIXME limit scale properly
+				mDrag = true;
 				mViewport.scaleMap(1 + my / (height / 6), 0, 0);
 				mMap.updateMap(true);
 				mStartMove = -1;


### PR DESCRIPTION
Per Android guidelines, double touch drag up should decrease content scale and double touch drag down should increase content scale. This is also the behavior in the official Google Maps Android application.

http://developer.android.com/design/patterns/gestures.html

This change set also adds double tap to zoom functionality using `Animator#animateZoom(...)`.
