### PR TITLE
align zoom behavior to Gmaps when having map centered around location

### DIFF
--- a/vtm/src/org/oscim/layers/MapEventLayer.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer.java
@@ -40,6 +40,9 @@ public class MapEventLayer extends Layer implements InputListener, GestureListen
 
 	static final Logger log = LoggerFactory.getLogger(MapEventLayer.class);
 
+	/* TODO create getter/setter? */
+	public boolean mFixedCenter = false;
+	
 	/* TODO replace with bitmasks */
 	private boolean mEnableRotate = true;
 	private boolean mEnableTilt = true;
@@ -143,10 +146,12 @@ public class MapEventLayer extends Layer implements InputListener, GestureListen
 			mDown = false;
 			if (mDoubleTap && !mDragZoom) {
 				/* handle double tap zoom */
-				mMap.animator().animateZoom(300, 2,
-				                            mPrevX1 - mMap.getWidth() / 2,
-				                            mPrevY1 - mMap.getHeight() / 2);
-
+				if (mFixedCenter)
+					mMap.animator().animateZoom(300, 2, 0, 0);
+				else
+					mMap.animator().animateZoom(300, 2,
+					                            mPrevX1 - mMap.getWidth() / 2,
+					                            mPrevY1 - mMap.getHeight() / 2);
 			} else if (mStartMove > 0) {
 				/* handle fling gesture */
 				mTracker.update(e.getX(), e.getY(), e.getTime());
@@ -342,12 +347,21 @@ public class MapEventLayer extends Layer implements InputListener, GestureListen
 
 		synchronized (mViewport) {
 			if (!mDoTilt) {
-				if (rotateBy != 0)
-					mViewport.rotateMap(rotateBy, fx, fy);
-				if (scaleBy != 1)
-					mViewport.scaleMap(scaleBy, fx, fy);
-
-				mViewport.moveMap(mx, my);
+				if (rotateBy != 0) {
+					if (mFixedCenter)
+						mViewport.rotateMap(rotateBy, 0, 0);
+					else
+						mViewport.rotateMap(rotateBy, fx, fy);
+				}
+				if (scaleBy != 1) {
+					if (mFixedCenter)
+						mViewport.scaleMap(scaleBy, 0, 0);
+					else
+						mViewport.scaleMap(scaleBy, fx, fy);
+				}
+ 
+ 				if (!mFixedCenter)
+					mViewport.moveMap(mx, my);
 			} else {
 				if (tiltBy != 0 && mViewport.tiltMap(-tiltBy))
 					mViewport.moveMap(0, my / 2);


### PR DESCRIPTION
Feature to switch double-tap zoom to either zoom around tap location (currently like that) or zoom around center of map, keeping this centered!
I need to be able to switch the two modes while the map is showing.

Another request that kinda fits in here (though not double tap, but still zoom)
Request
Feature to allow to disable zoom & drag map. Meaning
a) allow 2 finger zoom AND drag/move map at the same time
b) allow 2 finger zoom but dragging both fingers to move map will not move it

Good example is current Google Maps app.
for a) move map around and then do 2 finger zoom and then drag both fingers to move map
for b) center map on you and THEN do the above and you will see that the map does not move

Same procedure can be used to test the double tap zoom btw....
