### PR TITLE
implements okhttp response caching

### DIFF
--- a/vtm/src/org/oscim/tiling/source/OkHttpEngine.java
+++ b/vtm/src/org/oscim/tiling/source/OkHttpEngine.java
@@ -26,12 +26,15 @@ import java.util.Map.Entry;
 
 import org.oscim.core.Tile;
 import org.oscim.utils.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.squareup.okhttp.OkHttpClient;
 
 public class OkHttpEngine implements HttpEngine {
 	private final OkHttpClient mClient;
 	private final UrlTileSource mTileSource;
+	static final Logger log = LoggerFactory.getLogger(OkHttpEngine.class);
 
 	public static class OkHttpFactory implements HttpEngine.Factory {
 		private final OkHttpClient mClient;
@@ -50,6 +53,7 @@ public class OkHttpEngine implements HttpEngine {
 
 	public OkHttpEngine(OkHttpClient client, UrlTileSource tileSource) {
 		mClient = client;
+		mClient.setResponseCache(tileSource.getResponseCache());
 		mTileSource = tileSource;
 	}
 
@@ -89,7 +93,7 @@ public class OkHttpEngine implements HttpEngine {
 
 	@Override
 	public void setCache(OutputStream os) {
-		// TODO: Evaluate OkHttp response cache and determine if additional caching is required.
+		// OkHttp cache implented through tileSource setResponseCache
 	}
 
 	@Override

--- a/vtm/src/org/oscim/tiling/source/UrlTileSource.java
+++ b/vtm/src/org/oscim/tiling/source/UrlTileSource.java
@@ -16,6 +16,8 @@
  */
 package org.oscim.tiling.source;
 
+import com.squareup.okhttp.HttpResponseCache;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -31,6 +33,7 @@ public abstract class UrlTileSource extends TileSource {
 	private final URL mUrl;
 	private final String[] mTilePath;
 
+	private HttpResponseCache mResponseCache;
 	private HttpEngine.Factory mHttpFactory;
 	private Map<String, String> mRequestHeaders = Collections.emptyMap();
 	private TileUrlFormatter mTileUrlFormatter = URL_FORMATTER;
@@ -85,6 +88,14 @@ public abstract class UrlTileSource extends TileSource {
 
 	public void setHttpEngine(HttpEngine.Factory httpFactory) {
 		mHttpFactory = httpFactory;
+	}
+
+	public void setResponseCache(HttpResponseCache responseCache) {
+		mResponseCache = responseCache;
+	}
+
+	public HttpResponseCache getResponseCache() {
+		return mResponseCache;
 	}
 
 	public void setHttpRequestHeaders(Map<String, String> options) {


### PR DESCRIPTION
Creates a hook to add response cache to OkHttpEngine see usage here:

https://github.com/mapzen/mapzen-android-demo/commit/c5676301afbcee0f6f25a8e23b7e3ad0d5ed7d34#diff-22685a03f4ce00bbc95dc6d058cbc469R198
